### PR TITLE
ptp4l standalone config

### DIFF
--- a/manifests/ptp4l.pp
+++ b/manifests/ptp4l.pp
@@ -34,5 +34,16 @@ define linuxptp::ptp4l(
   file { "${::linuxptp::ptp4l_confdir}/${name}.conf":
     ensure  => file,
     content => template("${module_name}/ptp4l.conf.erb"),
+    notify  => Service[$linuxptp::ptp4l_service_name],
   }
+
+  file { "/etc/sysconfig/ptp4l":
+    ensure  => file,
+    content => template("${module_name}/ptp4l.erb"),
+    notify  => [
+      Service[$linuxptp::ptp4l_service_name],
+      Service[$linuxptp::phc2sys_service_name],
+    ],
+  }
+
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,6 +4,7 @@ class linuxptp::service inherits linuxptp {
     enable     => $ptp4l_service_enable,
     hasstatus  => true,
     hasrestart => true,
+    require    => Package[$linuxptp::package_name]
   }
 
   service { $phc2sys_service_name:
@@ -11,5 +12,6 @@ class linuxptp::service inherits linuxptp {
     enable     => $phc2sys_service_enable,
     hasstatus  => true,
     hasrestart => true,
+    require    => Package[$linuxptp::package_name]
   }
 }

--- a/spec/defines/ptp4l_spec.rb
+++ b/spec/defines/ptp4l_spec.rb
@@ -82,4 +82,10 @@ describe 'linuxptp::ptp4l' do
     let(:params) {{ :interfaces => [ 'eth0' ], :logMinPdelayReqInterval => 'foo', }}
     it { expect { should compile }.to raise_error(/Expected first argument to be a Numeric/) }
   end
+
+  context 'with two interfaces' do
+    let(:params) {{ :interfaces => [ 'eth0', 'eth1' ], }}
+    it { should contain_file('/etc/sysconfig/ptp4l').with_content(/ -i eth0 -i eth1/) }
+    it { should contain_file('/etc/sysconfig/ptp4l').with_content(/-f \/etc\/ptp4l\/test.conf /) }
+  end
 end

--- a/templates/ptp4l.erb
+++ b/templates/ptp4l.erb
@@ -1,0 +1,2 @@
+OPTIONS="-f <%= scope.lookupvar("linuxptp::ptp4l_confdir") %>/<%= @name %>.conf <% @interfaces.sort.each do |interface| -%>
+-i <%= interface -%> <% end -%>"


### PR DESCRIPTION
The current state of the module was not working without the supervisord setup proposed.

To have a working **standalone-setup**, the /etc/sysconfig/ptp4l config file is deployed via template to reflect the non-standard config location as well as the configured interfaces.

The standalone-setup is not multi-instance compatible as this would require to deploy multiple systemd unit files. (chosen limitation for this pull request)


**Second change** is a dependancy of the service. The service was started before the package installation was finished because of a missing dependancy.
