### PR TITLE
Added uds_name to phc2sys

### DIFF
--- a/manifests/phc2sys.pp
+++ b/manifests/phc2sys.pp
@@ -3,6 +3,7 @@
 #Creates the configuration for a single instance of phc2sys.
 class linuxptp::phc2sys(
   $summary_updates         = 0,
+  $uds_name                = 'ptp4l'
 ) {
   include ::linuxptp
 

--- a/templates/phc2sys.erb
+++ b/templates/phc2sys.erb
@@ -1,1 +1,1 @@
-OPTIONS="-a -r -u <%= @summary_updates -%>"
+OPTIONS="-a -r -u <%= @summary_updates -%> -z /var/run/ptp4l/<%= @uds_name %>"


### PR DESCRIPTION
Caused by the possibility to manage multiple ptp4l daemons, the uds_path of the ptp4l daemons has been modified from the default. As of this the phc2sys was not able to connect to the ptp4l via uds. 

This change allows to specify the uds name (not the full path) for the phc2sys. 