### PR TITLE
Fixed UDS path for single_instance mode

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,7 @@ class linuxptp(
       }
     }
     linuxptp::ptp4l { 'default':
+      single_instance             => $single_instance,
       filename                    => $conf_file,
       interfaces                  => $interfaces,
       network_transport           => $network_transport,

--- a/manifests/ptp4l.pp
+++ b/manifests/ptp4l.pp
@@ -4,6 +4,7 @@
 #instance is best done with supervisord.
 define linuxptp::ptp4l(
   $interfaces,
+  $single_instance             = false,
   $filename                    = undef,
   $network_transport           = 'UDPv4',
   $slave_only                  = 0,

--- a/templates/ptp4l.conf.erb
+++ b/templates/ptp4l.conf.erb
@@ -63,7 +63,11 @@ ptp_dst_mac		01:1B:19:00:00:00
 p2p_dst_mac		01:80:C2:00:00:0E
 udp_ttl			<%= @udp_ttl %>
 udp6_scope		0x0E
+<% if @single_instance -%>
+uds_address		/var/run/ptp4l
+<% else -%>
 uds_address		/var/run/ptp4l/<%= @name %>
+<% end -%>
 #
 # Default interface options
 #


### PR DESCRIPTION
For single instance, the uds path was not set correctly. As a result the ptp4l daemon could not create the uds file and the phc2sys could not connect to it.