### PR TITLE
Added option for message tag

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class linuxptp(
   $logdir                      = '/var/log/linuxptp',
   $manage_sysconfig            = true,
   $manage_logrotate_rule       = true,
+  $message_tag                 = '',
 ) {
   package { $package_name:
     ensure => present,
@@ -67,6 +68,7 @@ class linuxptp(
       delay_mechanism             => $delay_mechanism,
       time_stamping               => $time_stamping,
       summary_interval            => $summary_interval,
+      message_tag                 => $message_tag,
       require                     => Package[$package_name],
     }
 

--- a/manifests/phc2sys.pp
+++ b/manifests/phc2sys.pp
@@ -4,6 +4,7 @@
 class linuxptp::phc2sys(
   $summary_updates = 0,
   $uds_name        = 'ptp4l'
+  $message_tag     = '',
 ) {
   include ::linuxptp
 

--- a/manifests/ptp4l.pp
+++ b/manifests/ptp4l.pp
@@ -19,6 +19,7 @@ define linuxptp::ptp4l(
   $time_stamping               = 'hardware',
   $summary_interval            = 0,
   $ptp4l_confdir               = '/etc/ptp4l',
+  $message_tag                 = '',
 ) {
   validate_array($interfaces)
   validate_numeric($slave_only, 1, 0)

--- a/templates/phc2sys.erb
+++ b/templates/phc2sys.erb
@@ -1,1 +1,1 @@
-OPTIONS="-a -r -u <%= @summary_updates -%>"
+OPTIONS="-a -r -u <%= @summary_updates -%> <% if message_tag != '' %>-t <%= @message_tag %><% end %>"

--- a/templates/ptp4l.conf.erb
+++ b/templates/ptp4l.conf.erb
@@ -88,6 +88,10 @@ revisionData		;;
 manufacturerIdentity	00:00:00
 userDescription		;
 timeSource		0xA0
+#
+<% if message_tag != '' -%>
+message_tag         <%= @message_tag %>
+<% end -%>
 
 <% @interfaces.sort.each do |interface| -%>
 [<%= interface %>]

--- a/templates/ptp4l.conf.erb
+++ b/templates/ptp4l.conf.erb
@@ -89,7 +89,7 @@ manufacturerIdentity	00:00:00
 userDescription		;
 timeSource		0xA0
 #
-<% if message_tag != '' -%>
+<% if @message_tag != '' -%>
 message_tag         <%= @message_tag %>
 <% end -%>
 


### PR DESCRIPTION
In preparation for multi-interface ptp setup, I added the option for "message_tag" to both daemons (ptp4l and phc2sys). 

This allows to specify a tag which is added to every log line.